### PR TITLE
chore(scm): remove duplicate strings xml resource from src folder

### DIFF
--- a/library/src/debug/res/values/strings.xml
+++ b/library/src/debug/res/values/strings.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources></resources>


### PR DESCRIPTION
## Description of change

Removed debug folder under Library/src directory; the strings.xml resource already exists into src/main directory.

### Pull request (PR) check-list

> **:white_check_mark: Please review and check the appropriate items.**

1. **Type of change**
    - [ ] BREAKING CHANGE (with documentation) _Please explain if selected_
    - [ ] Chore
    - [ ] Defect (bug) fix (with regression tests)
    - [ ] Documentation
    - [ ] Feature/enhancement (with JavaDocs and/or Wiki article(s))
    - [ ] Hotfix (with documentation)
    - [ ] Performance improvement (with benchmarks)
    - [ ] Refactoring (with catalog reference)
    - [ ] Reversion
    - [ ] Tests
2. **Code standards compliance**
    - [ ] Yes, `checkstyle` passes.
    - [ ] N/A (not applicable): _Please explain if selected_
3. **Code quality**. Do the quality gateways pass with an "A" grade?
    - [ ] `Complexity`
    - [ ] `Duplications` (0.00%)
    - [ ] `Issues` (0 issues or documentation for "won't fix" cases)
    - [ ] `Maintainability`/`Technical Debt`
    - [ ] `Reliability`
    - [ ] `Security`
    - [ ] N/A (not applicable). _Please explain if selected_
4. **Test coverage**
    - [ ] The source code is 100% covered with passing specs.
    - [ ] N/A (not applicable). _Please explain if selected_

> **:information_source: These tasks are not required to open a PR and can be done afterwards, or while the PR is open.**
